### PR TITLE
Cleanup lndg install steps

### DIFF
--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -218,7 +218,7 @@ services:
       - lnd  
     volumes:  
       - ${oc.env:PWD}/volumes/lnd_datadir:/root/.lnd:ro
-      - ${oc.env:PWD}/volumes/lndg_datadir/data:/lndg/data:rw
+      - ${oc.env:PWD}/volumes/lndg_datadir:/lndg/data:rw
     command:  
       - sh  
       - -c  

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,6 @@ mkdir -p volumes/tor_datadir
 mkdir -p volumes/tor_servicesdir
 mkdir -p volumes/tor_torrcdir
 mkdir -p volumes/lndg_datadir
-touch    volumes/lndg_datadir/db.sqlite3
 
 docker-compose build --build-arg TRIPLET=$TRIPLET
 docker-compose up --remove-orphans -d


### PR DESCRIPTION
This cleans up the install steps slightly by putting data files directing into the lndg volumes folder and also removing the initialization of the db since it is no longer required.