### PR TITLE
Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ git clone https://github.com/PLEBNET-PLAYGROUND/plebnet-playground-docker --conf
 cd plebnet-playground-docker
 pip3 install -r requirements.txt
 ```
+Follow [these instructions](https://docs.docker.com/compose/install/#install-compose) to install the `docker compose` subcommand on your system (Mac, Windows, Windows Server 2016, or Linux systems). 
 
 ### Supported System Architectures
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ fi
 
 
 #Remove any old version
-docker-compose down
+docker compose down
 
 python3 plebnet_generate.py TRIPLET=$TRIPLET services=$services
 
@@ -47,5 +47,5 @@ mkdir -p volumes/tor_servicesdir
 mkdir -p volumes/tor_torrcdir
 mkdir -p volumes/lndg_datadir
 
-docker-compose build --build-arg TRIPLET=$TRIPLET
-docker-compose up --remove-orphans -d
+docker compose build --build-arg TRIPLET=$TRIPLET
+docker compose up --remove-orphans -d

--- a/worklogs/asherp.md
+++ b/worklogs/asherp.md
@@ -1,3 +1,4 @@
+* install instructions for Compose
 * switch to docker compose
 
 ### 2022-02-10 23:09:40.015116: clock-in

--- a/worklogs/asherp.md
+++ b/worklogs/asherp.md
@@ -1,3 +1,6 @@
+
+### 2022-02-10 23:09:40.015116: clock-in
+
 ### 2021-09-25 14:59:37.408376: clock-out
 
 * converted to undirected graph to capture all routes

--- a/worklogs/asherp.md
+++ b/worklogs/asherp.md
@@ -1,3 +1,5 @@
+### 2022-02-10 23:20:26.798951: clock-out
+
 * install instructions for Compose
 * switch to docker compose
 

--- a/worklogs/asherp.md
+++ b/worklogs/asherp.md
@@ -1,3 +1,4 @@
+* switch to docker compose
 
 ### 2022-02-10 23:09:40.015116: clock-in
 


### PR DESCRIPTION
Trying out `docker compose` a la #79

I seem to be getting more stable runs on my mac when switching to this.

```console
docker --version 
Docker version 20.10.8, build 3967b7d
```

We should probably point to the install instructions for compose [here](https://docs.docker.com/compose/install/). 