### PR TITLE
Modified getcoins.py to use c-lightning

### DIFF
--- a/PLAY.md
+++ b/PLAY.md
@@ -21,7 +21,7 @@ play-getcoins -a $(play-lnd getnewaddress)
 
 Nested Commands:
 play-getcoins -a $(play-lnd getnewaddress) && play-getcoins -a $(play-lnd getnewaddress)
-play-getcoins -a $(play-getcoins -r true)
+play-getcoins -a $(play-getcoins -r)
 
 ```
 ## PLAY-BITCOIN COMMAND

--- a/docs/docs/PLAY.md
+++ b/docs/docs/PLAY.md
@@ -21,7 +21,7 @@ play-getcoins -a $(play-lnd getnewaddress)
 
 Nested Commands:
 play-getcoins -a $(play-lnd getnewaddress) && play-getcoins -a $(play-lnd getnewaddress)
-play-getcoins -a $(play-getcoins -r true)
+play-getcoins -a $(play-getcoins -r)
 
 ```
 ## PLAY-BITCOIN COMMAND

--- a/getcoins.py
+++ b/getcoins.py
@@ -16,16 +16,15 @@ sys.path.append("/usr/local/lib/python3.8/site-packages")
 sys.path.append("/usr/local/lib/python3.9/site-packages")
 
 parser = argparse.ArgumentParser(description='Script to get coins from a faucet.')
-parser.add_argument('-c', '--cmd', dest='cmd', default='docker', help='bitcoin-cli command to use')
-parser.add_argument('-f', '--faucet', dest='faucet', default='http://signet.xenon.fun:5000/faucet', help='URL of the faucet')
-parser.add_argument('-a', '--address', dest='address', default='', help='Bitcoin address to which the faucet should send')
-parser.add_argument('-r', '--report', dest='report', default='false', help='Return session data')
-parser.add_argument('-s', '--success', dest='success', default='false', help='return 0 if true')
+parser.add_argument('-c', '--cmd', default='docker', help='bitcoin-cli command to use')
+parser.add_argument('-f', '--faucet', default='http://signet.xenon.fun:5000/faucet', help='URL of the faucet')
+parser.add_argument('-a', '--address', default='', help='Bitcoin address to which the faucet should send')
+parser.add_argument('-r', '--report', action='store_true', help='Return session data')
 
 args = parser.parse_args()
 
 def print_report():
-    if args.report == 'true':
+    if args.report == True:
         print(args.address)
         # NOTE: jq expected syntax
         # echo  {\"address\": \"tb1qhjd4lxv7vkqp7pen34t8zfxvvc8f8eqpppug26\"} | jq .

--- a/scripts/blocknotify
+++ b/scripts/blocknotify
@@ -1,7 +1,7 @@
 #!/bin/bash
 #BEGIN OF OBJECT
 
-play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r true) > /dev/null 2>&1
+play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r) > /dev/null 2>&1
 
 echo "{"
 echo "\"blocknotify\":["
@@ -25,8 +25,8 @@ echo { \"PLAY_BITCOIN_ADDRESS\": \"$PLAY_BITCOIN_ADDRESS\" },
 
 host-cli-automate(){
 ################################################################################
-play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r true) > /dev/null 2>&1
-play-getcoins -a $( echo  play-getcoins -a tb1qch72khdxtc8wd2rdzedut7269j5a3sjszapnck -r true) > /dev/null 2>&1
+play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r) > /dev/null 2>&1
+play-getcoins -a $( echo  play-getcoins -a tb1qch72khdxtc8wd2rdzedut7269j5a3sjszapnck -r) > /dev/null 2>&1
 
 
 #settxfee alwats less than 0.1000
@@ -114,11 +114,11 @@ do
                     echo "{ \"j\": \"$j\" },"
                     echo "{ \"k\": \"$k\" },"
 
-                    #play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r true) > /dev/null 2>&1
+                    #play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r) > /dev/null 2>&1
                     host-cli-automate
                     echo $(bitcoin-cli  -rpcwallet=playground-wallet getbalances),
                     echo $(play-bitcoin getbalances),
-                    #play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r true) > /dev/null 2>&1
+                    #play-getcoins -a $( echo  play-getcoins -a tb1qv07v5f0mmvnzczfs50c8wv8s76rrrdcr875y7z -r) > /dev/null 2>&1
 
                     #echo "{ \"COUNT\": \"$count\" },"
                 done

--- a/scripts/play
+++ b/scripts/play
@@ -158,7 +158,7 @@ export BTCD_IMAGE
         echo
         echo "Nested Commands:"
         echo "play-getcoins -a \$(play-lnd getnewaddress) && play-getcoins -a \$(play-lnd getnewaddress)"
-        echo "play-getcoins -a \$(play-getcoins -r true)"
+        echo "play-getcoins -a \$(play-getcoins -r)"
         echo
         exit
 


### PR DESCRIPTION
Just a quick change to `getcoins.py` to send coins to the c-lightning wallet. I've added a `-n` flag to select between lnd or c-lightning. The default is lnd so previous usage is unaffected. 

Unrelated to the c-lightning support, I also made a few tidy up changes to argument definitions. @RandyMcMillan just a heads up I touched the -r and -s flags that you added. See the full commit message for details. It's just a suggestion, happy to back these changes out. 