### PR TITLE
scripts/initialize: brew install docker && brew link docker

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -73,6 +73,8 @@ if hash brew 2>/dev/null; then
     #brew install python@3.8
     if ! hash docker 2>/dev/null; then
         brew install --cask docker
+        brew install docker
+        brew link docker
     fi
     if ! hash docker-compose 2>/dev/null; then
         brew install docker-compose


### PR DESCRIPTION
Notes:

brew install --cask docker installs the GUI app on macOS
brew install docker installs the command line daemon
For the play command to work - the daemon version must be installed
homebrew used to link the docker command when the GUI version was installed.