### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This package will setup a bitcoind, lnd, and tor daemon that will connect to the
 ```
 git clone https://github.com/PLEBNET-PLAYGROUND/plebnet-playground-docker --config core.autocrlf=input
 cd plebnet-playground-docker
+python3 -m venv venv 
+source venv/bin/activate
 pip3 install -r requirements.txt
 ```
 Follow [these instructions](https://docs.docker.com/compose/install/#install-compose) to install the `docker compose` subcommand on your system (Mac, Windows, Windows Server 2016, or Linux systems). 


### PR DESCRIPTION
use a virtualenv, best practice for managing python environments from the beginning, as each project (esp if one is running multiple projects like myself) may have different requirements and this way we avoid polluting the global python environment.