### PR TITLE
shallow git clones

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install grpcio grpcio-tools googleapis-common-protos
 
 WORKDIR /grpc
 
-RUN git clone https://github.com/googleapis/googleapis.git
+RUN git clone --depth 1 https://github.com/googleapis/googleapis.git
 RUN wget https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/lightning.proto
 RUN python -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. lightning.proto
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -27,7 +27,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # Set build directory
 RUN apk add git
-RUN git clone https://github.com/mkdocs/mkdocs.git /tmp
+RUN git clone --depth 1 https://github.com/mkdocs/mkdocs.git /tmp
 RUN apk del git
 WORKDIR /tmp
 # Copy files necessary for build

--- a/lnbits/Dockerfile
+++ b/lnbits/Dockerfile
@@ -4,10 +4,10 @@
 # Install build deps, python3.8 from ubuntu 20.04 works for lnbits
 FROM ubuntu:20.04
 RUN apt-get -y update
-RUN apt-get install -y --no-install-recommends build-essential pkg-config 
+RUN apt-get install -y --no-install-recommends build-essential pkg-config
 RUN apt install -y python3-pip postgresql-client
 RUN pip3 install wheel
-RUN apt-get -y install git libffi-dev libpq-dev 
+RUN apt-get -y install git libffi-dev libpq-dev
 
 # Copy in app source
 WORKDIR /app
@@ -15,7 +15,7 @@ WORKDIR /app
 # clone repository
 RUN git clone https://github.com/lnbits/lnbits-legend /app/lnbits
 WORKDIR /app/lnbits
-RUN git checkout 11006ef7ed34e226629bad4f4b614e21c4df1ec4
+RUN git reset --hard 11006ef7ed34e226629bad4f4b614e21c4df1ec4
 
 
 # Install runtime deps
@@ -29,7 +29,7 @@ RUN mkdir -p /app/lnbits/data
 RUN pip3 install pylightning
 
 # Install LND specific deps - has trouble installing
-RUN pip3 install lndgrpc 
+RUN pip3 install lndgrpc
 RUN pip3 install psycopg2
 
 


### PR DESCRIPTION
Using `git clone --depth 1 <repo_url>` on some repos reduces container footprint. 