### PR TITLE
thunderhub v0.13.18 fixes expectedcommitmenttypeinchannelmessage error

### DIFF
--- a/thub/Dockerfile
+++ b/thub/Dockerfile
@@ -1,4 +1,4 @@
-FROM apotdevin/thunderhub:v0.12.24 as playground-thunderhub
+FROM apotdevin/thunderhub:v0.13.18 as playground-thunderhub
 LABEL org.opencontainers.image.authors="Richard Safier"
 LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.source="https://github.com/PLEBNET-PLAYGROUND/plebnet-playground-docker"
@@ -14,4 +14,4 @@ COPY docker-entrypoint.sh /usr/local/etc/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/etc/entrypoint.sh"]
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
MacOS Ventura 
Cluster setup `./up-x64.sh 3`
Added thunderhub service to docker-compose too.

After adding a few channels between nodes, I was no longer able to login to thunderhub, and got the following.
`error: expectedcommitmenttypeinchannelmessage`

similar issue here [after adding channels issue](https://github.com/apotdevin/thunderhub/issues/493). 
This recommended upgrading to v0.13.18, which did resolve the issue.

Also, with this version `npm run start` no longer worked. [ref issue](https://github.com/apotdevin/thunderhub/issues/435#issuecomment-1340296092) Need to use `npm run start:prod` instead.
