### PR TITLE
make: docker-install: install Docker.App for MacOS Catalina

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -424,6 +424,10 @@ endif
 
 	#pushd scripts 2>/dev/null; for string in *; do sudo chmod -R o+rwx /usr/local/bin/$$string; done; popd  2>/dev/null || echo
 
+docker-install:
+	@echo "TODO: detect if macos arm64 or intel"
+	@echo "Install Docker.amd64.68347.dmg if MacOS Catalina - known compatible version!"
+	@curl -o Docker.amd64.68347.dmg  https://desktop.docker.com/mac/main/amd64/68347/Docker.dmg
 
 #######################
 .ONESHELL:


### PR DESCRIPTION
Docker.app support for MacOS Catalina (Intel) is quasi-deprecated in homebrew currently.
It is likely an over sight in the home-brew docker cask.
Adding a make command to DL a Catalina compatible version.
